### PR TITLE
Skip FOSSA scan for Dependabot PRs

### DIFF
--- a/.github/workflows/code-scan.yaml
+++ b/.github/workflows/code-scan.yaml
@@ -34,6 +34,7 @@ jobs:
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@192325c86100d080feab897ff886c34abd4c83a3 # v3.30.3
   fossa:
+    if: (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
Dependabot PRs can not read org secrets.