### PR TITLE
Update kind to v0.32.0 in setup-kubernetes

### DIFF
--- a/.github/actions/setup-kubernetes/action.yml
+++ b/.github/actions/setup-kubernetes/action.yml
@@ -8,7 +8,7 @@ inputs:
   kind-version:
     description: 'Kind version to setup'
     required: false
-    default: 'v0.30.0'
+    default: 'v0.32.0'
 runs:
   using: "composite"
   steps:


### PR DESCRIPTION
This makes the default cluster version be Kubernetes 1.36

Part of: https://github.com/fluxcd/flux2/issues/5864