### PR TITLE
Add options to setup-kubernetes

### DIFF
--- a/.github/actions/setup-kubernetes/action.yml
+++ b/.github/actions/setup-kubernetes/action.yml
@@ -9,6 +9,13 @@ inputs:
     description: 'Kind version to setup'
     required: false
     default: 'v0.32.0'
+  cluster-name:
+    description: 'Name of the kind cluster'
+    required: false
+    default: 'kind'
+  kind-config:
+    description: 'Path to a kind cluster configuration file (optional)'
+    required: false
 runs:
   using: "composite"
   steps:
@@ -32,4 +39,5 @@ runs:
       uses: helm/kind-action@ef37e7f390d99f746eb8b610417061a60e82a6cc # v1.14.0
       with:
         version: ${{ inputs.kind-version }}
-        cluster_name: kind
+        cluster_name: ${{ inputs.cluster-name }}
+        config: ${{ inputs.kind-config }}

--- a/.github/actions/setup-kubernetes/action.yml
+++ b/.github/actions/setup-kubernetes/action.yml
@@ -16,19 +16,32 @@ inputs:
   kind-config:
     description: 'Path to a kind cluster configuration file (optional)'
     required: false
+  skip-checkout:
+    description: 'Skip checking out the repository (useful when the caller has already run checkout)  Example: generating kind-configs / spinning up multiple clusters'
+    required: false
+    default: 'false'
+  skip-tools:
+    description: 'Skip the toolchain setup steps (Kustomize, QEMU, Buildx, Go) and only create the kind cluster  Example: spinning up a second or third cluster after a first run of this action has already setup tools'
+    required: false
+    default: 'false'
 runs:
   using: "composite"
   steps:
     - name: Checkout
+      if: ${{ inputs.skip-checkout != 'true' }}
       uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
     - name: Setup Kustomize
+      if: ${{ inputs.skip-tools != 'true' }}
       uses: fluxcd/pkg/actions/kustomize@f3ad4b56adec90eb5661af565cdebec997ad4bfb # main
     - name: Setup QEMU
+      if: ${{ inputs.skip-tools != 'true' }}
       uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3 # v4.1.0
     - name: Setup Docker Buildx
       id: buildx
+      if: ${{ inputs.skip-tools != 'true' }}
       uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
     - name: Setup Go
+      if: ${{ inputs.skip-tools != 'true' }}
       uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
       with:
         go-version: ${{ inputs.go-version }}

--- a/README.md
+++ b/README.md
@@ -284,6 +284,19 @@ jobs:
 The [setup-kubernetes](.github/actions/setup-kubernetes/action.yml) composite action configures
 the GitHub runner to build and test Flux controllers with Kubernetes Kind clusters.
 
+Inputs:
+
+- `go-version` (string, required): Go version to set up.
+- `kind-version` (string, optional): Kind version to set up.
+- `cluster-name` (string, optional): Name of the kind cluster.
+- `kind-config` (string, optional): Path to a kind cluster configuration file.
+- `skip-checkout` (boolean, optional, default `false`): Skip checking out the repository when the caller
+  has already run checkout. Useful for generating dynamic kind configs or spinning up multiple clusters
+  in a single job.
+- `skip-tools` (boolean, optional, default `false`): Skip the toolchain setup steps (Kustomize, QEMU,
+  Buildx, Go) and only create the kind cluster. Useful when spinning up a second or third cluster in a single
+  job after the tools have already been set up by a prior run.
+
 Example usage:
 
 ```yaml
@@ -303,6 +316,46 @@ jobs:
         with:
           go-version: 1.25.x
           kind-version: v0.30.0
+      - name: Run tests
+        run: make test
+```
+
+To generate dynamic kind configs or run against multiple clusters in a single job, check out the
+repository once and reuse the toolchain. The first invocation sets up the tools and creates a cluster;
+each subsequent invocation sets `skip-checkout: true` and `skip-tools: true` to only create an
+additional cluster:
+
+```yaml
+name: e2e-multicluster
+on:
+  pull_request:
+  push:
+    branches: [ main ]
+jobs:
+  kind:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read # for reading the repository code.
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+      - name: Generate kind configs
+        run: ./hack/gen-kind-configs.sh # writes /tmp/kind-cluster-1.yaml, /tmp/kind-cluster-2.yaml
+      - name: Setup tools and cluster 1
+        uses: fluxcd/gha-workflows/.github/actions/setup-kubernetes@vX.Y.Z
+        with:
+          go-version: 1.25.x
+          cluster-name: cluster-1
+          kind-config: /tmp/kind-cluster-1.yaml
+          skip-checkout: true
+      - name: Setup cluster 2
+        uses: fluxcd/gha-workflows/.github/actions/setup-kubernetes@vX.Y.Z
+        with:
+          go-version: 1.25.x
+          cluster-name: cluster-2
+          kind-config: /tmp/kind-cluster-2.yaml
+          skip-checkout: true
+          skip-tools: true
       - name: Run tests
         run: make test
 ```


### PR DESCRIPTION
Add four optional, backward-compatible inputs to the `setup-kubernetes`
composite action:

- `cluster-name` — name of the kind cluster (default `kind`)
- `kind-config` — path to a custom kind cluster config
- `skip-checkout` — gate the Checkout step when the caller has already
  checked out
- `skip-tools` — gate the Kustomize/QEMU/Buildx/Go setup steps and only
  create the kind cluster

These are sensible options to customize kind clusters in CI to match
local make/scripts and to set up custom infra. I intend to use these to
stand up the sigstore stack, which requires configuring the kube
apiserver and containerd.

The alternative is basically copying the pieces of this action
independently, duplicating it into source-controller actions so we can
control the checkout flow and kind config. This seemed like the cleanest
way for us to keep our Dependabot updates in one place.
