### PR TITLE
Create draft PRs for backport conflicts

### DIFF
--- a/.github/workflows/backport.yaml
+++ b/.github/workflows/backport.yaml
@@ -25,6 +25,11 @@ jobs:
           github_token: ${{ secrets.github-token }}
           # Match labels with a pattern `backport:<target-branch>`
           label_pattern: '^backport:([^ ]+)$'
+          # Open draft PRs when cherry-picks have conflicts
+          experimental: |
+            {
+              "conflict_resolution": "draft_commit_conflicts"
+            }
           # A bit shorter pull-request title than the default
           pull_title: '[${target_branch}] ${pull_title}'
           # Simpler PR description than default

--- a/README.md
+++ b/README.md
@@ -117,7 +117,8 @@ jobs:
 
 The [backport](.github/workflows/backport.yaml) workflow automates the backporting of merged pull
 requests to release branches based on labels in the format `backport:release/semver`
-(e.g. `backport:release/v2.0.x`).
+(e.g. `backport:release/v2.0.x`). If a cherry-pick conflicts, the workflow opens a
+draft pull request with the conflict committed for manual resolution.
 
 Example usage:
 


### PR DESCRIPTION
Summary:
- Configure the backport workflow to open draft PRs when cherry-picks conflict.
- Document the conflicted backport behavior.

Testing:
- yq eval '.' .github/workflows/backport.yaml >/dev/null